### PR TITLE
#4: API Word Filter

### DIFF
--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -10,8 +10,11 @@ pub async fn get_frequency(words: Json<Words>) -> HttpResponse {
     // TODO: See if we can move this to a static location
     let bible_words = get_file_as_map();
     let split_words = words.words.split(" ");
-    let word_freq: Vec<Option<ReturnInfo>> =
-        split_words.map(|word| lookup(&bible_words, word)).collect();
+    let word_freq: Vec<ReturnInfo> = split_words
+        .map(|word| lookup(&bible_words, word))
+        .filter(|item| item.is_some())
+        .map(|item| item.unwrap())
+        .collect();
     HttpResponse::Ok().json(word_freq)
 }
 

--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -12,7 +12,6 @@ pub async fn get_frequency(words: Json<Words>) -> HttpResponse {
     let split_words = words.words.split(" ");
     let word_freq: Vec<Option<ReturnInfo>> =
         split_words.map(|word| lookup(&bible_words, word)).collect();
-
     HttpResponse::Ok().json(word_freq)
 }
 
@@ -20,10 +19,9 @@ fn lookup<'a>(
     bible_words: &'a HashMap<String, Vec<WordInfo>>,
     word: &str,
 ) -> Option<ReturnInfo<'a>> {
-    let found_word_info = bible_words.get(word);
-    match found_word_info {
-        Some(info) => Some(ReturnInfo {
-            matches: Vec::from_iter(info.iter()),
+    match bible_words.get(word) {
+        Some(found_word_info) => Some(ReturnInfo {
+            matches: Vec::from_iter(found_word_info.iter()),
         }),
         None => None,
     }

--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -46,7 +46,7 @@ mod tests {
     use std::str::from_utf8;
 
     #[actix_web::test]
-    async fn test_response_ok() {
+    async fn test_formatted_response_code_200_ok() {
         let test_words = Words {
             words: "I miss Fauna".to_string(),
         };
@@ -56,27 +56,32 @@ mod tests {
     }
 
     #[actix_web::test]
-    async fn test_body_ok() {
+    async fn test_missing_word_returns_empty_array() {
         let test_words = Words {
-            words: "I miss Fauna".to_string(),
+            words: "Fauna".to_string(),
         };
-        let expected_output: Vec<WordInfo> = vec![
-            WordInfo {
-                book: "I".to_string(),
-                chapter: 1,
-                verse: 1,
-            },
-            WordInfo {
-                book: "miss".to_string(),
-                chapter: 1,
-                verse: 1,
-            },
-            WordInfo {
-                book: "Fauna".to_string(),
-                chapter: 1,
-                verse: 1,
-            },
-        ];
+        let expected_output: Vec<ReturnInfo> = Vec::new();
+        let json_words = Json(test_words);
+        let resp = get_frequency(json_words).await;
+        let byte_body = to_bytes(resp.into_body()).await.unwrap();
+        let string_body = from_utf8(&byte_body).unwrap();
+        assert_eq!(string_body, json!(expected_output).to_string())
+    }
+
+    #[actix_web::test]
+    async fn test_present_word_returns_array_of_return_info() {
+        let test_words = Words {
+            // For some reason, this is one of the only words that only appears once in the bible/
+            words: "Girl".to_string(),
+        };
+        let expected_info = WordInfo {
+            book: "Joel".to_string(),
+            chapter: 3,
+            verse: 3,
+        };
+        let expected_output: Vec<ReturnInfo> = vec![ReturnInfo {
+            matches: vec![&expected_info],
+        }];
         let json_words = Json(test_words);
         let resp = get_frequency(json_words).await;
         let byte_body = to_bytes(resp.into_body()).await.unwrap();

--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -31,7 +31,7 @@ fn lookup<'a>(
 }
 
 pub fn config(cfg: &mut web::ServiceConfig) {
-    cfg.service(web::scope("/api").route("/test", web::post().to(get_frequency)));
+    cfg.service(web::scope("/api").route("/lookup", web::post().to(get_frequency)));
 }
 
 #[cfg(test)]

--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -1,25 +1,24 @@
+use crate::models::wordinfo::WordInfo;
+use crate::models::words::Words;
 use actix_web::web;
-use actix_web::{web::{
-    Json,
-}, post, HttpResponse};
-use crate::parser::WordInfo;
-use crate::{models::words::Words};
+use actix_web::{post, web::Json, HttpResponse};
 
 pub async fn get_frequency(words: Json<Words>) -> HttpResponse {
-    let mut word_freq : Vec<WordInfo> = Vec::new();  
+    let mut word_freq: Vec<WordInfo> = Vec::new();
     let split_words: Vec<&str> = words.words.split(" ").collect();
-    for word in split_words{
+    for word in split_words {
         // Compute the frequency and details and such
-        word_freq.push(WordInfo { book: word.to_string(), chapter: 1, verse: 1 })
+        word_freq.push(WordInfo {
+            book: word.to_string(),
+            chapter: 1,
+            verse: 1,
+        })
     }
     HttpResponse::Ok().json(word_freq)
 }
 
 pub fn config(cfg: &mut web::ServiceConfig) {
-    cfg.service(
-        web::scope("/api")
-            .route("/test", web::post().to(get_frequency))
-    );
+    cfg.service(web::scope("/api").route("/test", web::post().to(get_frequency)));
 }
 
 #[cfg(test)]
@@ -27,15 +26,15 @@ mod tests {
 
     use super::*;
     use actix_web::{
+        body::to_bytes,
         http::{self},
-        body::{to_bytes},
     };
     use serde_json::json;
     use std::str::from_utf8;
 
     #[actix_web::test]
     async fn test_response_ok() {
-        let test_words = Words{
+        let test_words = Words {
             words: "I miss Fauna".to_string(),
         };
         let json_words = web::Json(test_words);
@@ -45,14 +44,25 @@ mod tests {
 
     #[actix_web::test]
     async fn test_body_ok() {
-        let test_words = Words{
+        let test_words = Words {
             words: "I miss Fauna".to_string(),
         };
         let expected_output: Vec<WordInfo> = vec![
-            WordInfo{ book: "I".to_string(), chapter: 1, verse: 1 },
-            WordInfo{ book: "miss".to_string(), chapter: 1, verse: 1 },
-            WordInfo{ book: "Fauna".to_string(), chapter: 1, verse: 1 },
-
+            WordInfo {
+                book: "I".to_string(),
+                chapter: 1,
+                verse: 1,
+            },
+            WordInfo {
+                book: "miss".to_string(),
+                chapter: 1,
+                verse: 1,
+            },
+            WordInfo {
+                book: "Fauna".to_string(),
+                chapter: 1,
+                verse: 1,
+            },
         ];
         let json_words = web::Json(test_words);
         let resp = get_frequency(json_words).await;

--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -1,18 +1,23 @@
+use crate::models::returninfo::ReturnInfo;
 use crate::models::wordinfo::WordInfo;
 use crate::models::words::Words;
+use crate::parser::get_file_as_map;
 use actix_web::web;
-use actix_web::{post, web::Json, HttpResponse};
+use actix_web::{web::Json, HttpResponse};
 
 pub async fn get_frequency(words: Json<Words>) -> HttpResponse {
-    let mut word_freq: Vec<WordInfo> = Vec::new();
-    let split_words: Vec<&str> = words.words.split(" ").collect();
+    // TODO: See if we can move this to a static location
+    let bible_words = get_file_as_map();
+    let mut word_freq: Vec<ReturnInfo> = Vec::new();
+    let split_words = words.words.split(" ");
     for word in split_words {
-        // Compute the frequency and details and such
-        word_freq.push(WordInfo {
-            book: word.to_string(),
-            chapter: 1,
-            verse: 1,
-        })
+        let found_word_info = bible_words.get(word);
+        if found_word_info.is_some() {
+            // Create return info from found word
+            word_freq.push(ReturnInfo {
+                matches: Vec::from_iter(found_word_info.unwrap().iter()),
+            });
+        }
     }
     HttpResponse::Ok().json(word_freq)
 }

--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -4,22 +4,29 @@ use crate::models::words::Words;
 use crate::parser::get_file_as_map;
 use actix_web::web;
 use actix_web::{web::Json, HttpResponse};
+use std::collections::HashMap;
 
 pub async fn get_frequency(words: Json<Words>) -> HttpResponse {
     // TODO: See if we can move this to a static location
     let bible_words = get_file_as_map();
-    let mut word_freq: Vec<ReturnInfo> = Vec::new();
     let split_words = words.words.split(" ");
-    for word in split_words {
-        let found_word_info = bible_words.get(word);
-        if found_word_info.is_some() {
-            // Create return info from found word
-            word_freq.push(ReturnInfo {
-                matches: Vec::from_iter(found_word_info.unwrap().iter()),
-            });
-        }
-    }
+    let word_freq: Vec<Option<ReturnInfo>> =
+        split_words.map(|word| lookup(&bible_words, word)).collect();
+
     HttpResponse::Ok().json(word_freq)
+}
+
+fn lookup<'a>(
+    bible_words: &'a HashMap<String, Vec<WordInfo>>,
+    word: &str,
+) -> Option<ReturnInfo<'a>> {
+    let found_word_info = bible_words.get(word);
+    match found_word_info {
+        Some(info) => Some(ReturnInfo {
+            matches: Vec::from_iter(info.iter()),
+        }),
+        None => None,
+    }
 }
 
 pub fn config(cfg: &mut web::ServiceConfig) {
@@ -42,7 +49,7 @@ mod tests {
         let test_words = Words {
             words: "I miss Fauna".to_string(),
         };
-        let json_words = web::Json(test_words);
+        let json_words = Json(test_words);
         let resp = get_frequency(json_words).await;
         assert_eq!(resp.status(), http::StatusCode::OK);
     }
@@ -69,7 +76,7 @@ mod tests {
                 verse: 1,
             },
         ];
-        let json_words = web::Json(test_words);
+        let json_words = Json(test_words);
         let resp = get_frequency(json_words).await;
         let byte_body = to_bytes(resp.into_body()).await.unwrap();
         let string_body = from_utf8(&byte_body).unwrap();

--- a/api/src/models/mod.rs
+++ b/api/src/models/mod.rs
@@ -1,1 +1,2 @@
+pub mod wordinfo;
 pub mod words;

--- a/api/src/models/mod.rs
+++ b/api/src/models/mod.rs
@@ -1,2 +1,3 @@
 pub mod wordinfo;
 pub mod words;
+pub mod returninfo;

--- a/api/src/models/returninfo.rs
+++ b/api/src/models/returninfo.rs
@@ -1,0 +1,8 @@
+use crate::models::wordinfo::WordInfo;
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub struct ReturnInfo<'a> {
+    pub matches: Vec<&'a WordInfo>,
+    // TODO: Expand with other fields
+}

--- a/api/src/models/wordinfo.rs
+++ b/api/src/models/wordinfo.rs
@@ -1,0 +1,8 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize)]
+pub struct WordInfo {
+    pub book: String,
+    pub chapter: u8,
+    pub verse: u8,
+}

--- a/api/src/parser.rs
+++ b/api/src/parser.rs
@@ -1,12 +1,5 @@
-use serde::{Deserialize, Serialize};
+use crate::models::wordinfo::WordInfo;
 use std::collections::HashMap;
-
-#[derive(Deserialize, Serialize)]
-pub struct WordInfo {
-    pub book: String,
-    pub chapter: u8,
-    pub verse: u8,
-}
 
 pub fn get_file_as_map() -> HashMap<String, Vec<WordInfo>> {
     let words_string = std::fs::read_to_string("assets/words.json").expect("Words file not found");


### PR DESCRIPTION
Resolves #4.

This PR includes the implementation of the lookup logic for given words, returning information from an altered endpoint (now /api/lookup). This PR does not implement differentiation between instances of the same words, or case-sensitivity issues which will be addressed in subsequent PRs.