### PR TITLE
API Word position

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -10,3 +10,7 @@ actix-web = "4.3.1"
 serde = { version = "1.0.163", features = ["derive"]}
 serde_json = "1.0.96"
 once_cell = "1.18.0"
+unicode-segmentation = "1.10.1"
+
+[dev-dependencies]
+assert-json-diff = "2.0.2"

--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -23,9 +23,9 @@ pub async fn get_frequency(words: Json<Words>) -> HttpResponse {
 fn lookup<'a>(index: usize, word: &str) -> Option<ReturnInfo<'a>> {
     match BIBLE_WORDS.get(word) {
         Some(found_word_info) => Some(ReturnInfo {
-            matches: Vec::from_iter(found_word_info.iter()),
             start_pos: index,
             end_pos: index + word.len() - 1,
+            matches: Vec::from_iter(found_word_info.iter()),
         }),
         None => None,
     }
@@ -39,7 +39,7 @@ pub fn config(cfg: &mut web::ServiceConfig) {
 mod tests {
 
     use super::*;
-    use actix_web::body::BoxBody;
+
     use actix_web::{
         body::to_bytes,
         http::{self},

--- a/api/src/models/returninfo.rs
+++ b/api/src/models/returninfo.rs
@@ -3,6 +3,7 @@ use serde::Serialize;
 
 #[derive(Serialize)]
 pub struct ReturnInfo<'a> {
+    pub start_pos: usize,
+    pub end_pos: usize,
     pub matches: Vec<&'a WordInfo>,
-    // TODO: Expand with other fields
 }


### PR DESCRIPTION
This PR implements #6.

This PR introduces a new dependency to allow for indexing of segments, which is not supported in Rust std without some shaky pointer arithmetic. This does not appear to impact performance. This also introduces a dev dependency for better JSON comparison and the use of the generic serde_json::Value type in related testing over the previous string-based methodology, which had the unintended consequence of failing when field serialisation order was inconsistent.