### PR TITLE
Fix CI lint

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,5 +18,5 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Run lint
-        run: cargo fmt
+        run: cargo fmt --check
         working-directory: ./api

--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -28,8 +28,13 @@ fn lookup<'a>(index: usize, word: &str) -> Option<ReturnInfo<'a>> {
             matches: Vec::from_iter(found_word_info.iter()),
             links: found_word_info
                 .iter()
-                .map(|item| format!("https://www.kingjamesbibleonline.org/{}-{}-{}/", item.book, item.chapter, item.verse))
-                .collect()
+                .map(|item| {
+                    format!(
+                        "https://www.kingjamesbibleonline.org/{}-{}-{}/",
+                        item.book, item.chapter, item.verse
+                    )
+                })
+                .collect(),
         }),
         None => None,
     }
@@ -89,7 +94,7 @@ mod tests {
             start_pos: 0,
             end_pos: 3,
             matches: vec![&expected_info],
-            links: vec!["https://www.kingjamesbibleonline.org/Joel-3-3/".to_string()]
+            links: vec!["https://www.kingjamesbibleonline.org/Joel-3-3/".to_string()],
         }];
         let json_words = Json(test_words);
         let resp = get_frequency(json_words).await;
@@ -112,13 +117,13 @@ mod tests {
                 start_pos: 0,
                 end_pos: 3,
                 matches: vec![&expected_info],
-                links: vec!["https://www.kingjamesbibleonline.org/Joel-3-3/".to_string()]
+                links: vec!["https://www.kingjamesbibleonline.org/Joel-3-3/".to_string()],
             },
             ReturnInfo {
                 start_pos: 5,
                 end_pos: 8,
                 matches: vec![&expected_info],
-                links: vec!["https://www.kingjamesbibleonline.org/Joel-3-3/".to_string()]
+                links: vec!["https://www.kingjamesbibleonline.org/Joel-3-3/".to_string()],
             },
         ];
         let json_words = Json(test_words);
@@ -141,7 +146,7 @@ mod tests {
             start_pos: 0,
             end_pos: 3,
             matches: vec![&expected_info],
-            links: vec!["https://www.kingjamesbibleonline.org/Joel-3-3/".to_string()]
+            links: vec!["https://www.kingjamesbibleonline.org/Joel-3-3/".to_string()],
         }];
         let json_words = Json(test_words);
         let resp = get_frequency(json_words).await;
@@ -163,7 +168,7 @@ mod tests {
             start_pos: 0,
             end_pos: 3,
             matches: vec![&expected_info],
-            links: vec!["https://www.kingjamesbibleonline.org/Joel-3-3/".to_string()]
+            links: vec!["https://www.kingjamesbibleonline.org/Joel-3-3/".to_string()],
         }];
         let json_words = Json(test_words);
         let resp = get_frequency(json_words).await;
@@ -185,7 +190,7 @@ mod tests {
             start_pos: 0,
             end_pos: 3,
             matches: vec![&expected_info],
-            links: vec!["https://www.kingjamesbibleonline.org/Joel-3-3/".to_string()]
+            links: vec!["https://www.kingjamesbibleonline.org/Joel-3-3/".to_string()],
         }];
         let json_words = Json(test_words);
         let resp = get_frequency(json_words).await;

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1,9 +1,8 @@
-mod parser;
-mod models;
 mod handlers;
+mod models;
+mod parser;
 
 use actix_web::{get, App, HttpResponse, HttpServer, Responder};
-
 
 #[get("/hello")]
 async fn hello() -> impl Responder {
@@ -11,10 +10,8 @@ async fn hello() -> impl Responder {
 }
 
 #[actix_web::main]
-async fn main() -> std::io::Result<()> {  
-    HttpServer::new(move || App::new()
-        .configure(handlers::config)
-        .service(hello))
+async fn main() -> std::io::Result<()> {
+    HttpServer::new(move || App::new().configure(handlers::config).service(hello))
         .bind(("127.0.0.1", 8000))?
         .run()
         .await

--- a/api/src/models/mod.rs
+++ b/api/src/models/mod.rs
@@ -1,3 +1,3 @@
+pub mod returninfo;
 pub mod wordinfo;
 pub mod words;
-pub mod returninfo;

--- a/api/src/models/returninfo.rs
+++ b/api/src/models/returninfo.rs
@@ -6,5 +6,5 @@ pub struct ReturnInfo<'a> {
     pub start_pos: usize,
     pub end_pos: usize,
     pub matches: Vec<&'a WordInfo>,
-    pub links: Vec<String>
+    pub links: Vec<String>,
 }

--- a/api/src/models/words.rs
+++ b/api/src/models/words.rs
@@ -1,12 +1,12 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct Words{
+pub struct Words {
     pub words: String,
 }
 
 impl Words {
-    pub fn from_text(text: String) -> Self{
+    pub fn from_text(text: String) -> Self {
         Words { words: text }
     }
 }


### PR DESCRIPTION
An error was made in the way we originally used cargo fmt - this was applying fixes on the runner and leaving them uncommitted rather than flagging issues to be fixed by a human. The --check flag has been added to rectify this behaviour.