### PR TITLE
API: Added match info

### DIFF
--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -22,23 +22,21 @@ pub async fn get_frequency(words: Json<Words>) -> HttpResponse {
 }
 
 fn lookup<'a>(index: usize, word: &str) -> Option<ReturnInfo<'a>> {
-    match BIBLE_WORDS.get(word) {
-        Some(found_word_info) => Some(ReturnInfo {
-            start_pos: index,
-            end_pos: index + word.len() - 1,
-            matches: found_word_info
-                .into_iter()
-                .map(|item| MatchInfo {
-                    word_info: item,
-                    link: format!(
-                        "https://www.kingjamesbibleonline.org/{}-{}-{}/",
-                        item.book, item.chapter, item.verse
-                    ),
-                })
-                .collect(),
-        }),
-        None => None,
-    }
+    let found_word_info = BIBLE_WORDS.get(word)?;
+    Some(ReturnInfo {
+        start_pos: index,
+        end_pos: index + word.len() - 1,
+        matches: found_word_info
+            .into_iter()
+            .map(|item| MatchInfo {
+                word_info: item,
+                link: format!(
+                    "https://www.kingjamesbibleonline.org/{}-{}-{}/",
+                    item.book, item.chapter, item.verse
+                ),
+            })
+            .collect(),
+    })
 }
 
 pub fn config(cfg: &mut web::ServiceConfig) {
@@ -47,8 +45,8 @@ pub fn config(cfg: &mut web::ServiceConfig) {
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
+    use std::ops::Deref;
 
     use actix_web::{
         body::to_bytes,
@@ -57,6 +55,17 @@ mod tests {
     use assert_json_diff::assert_json_eq;
     use serde_json::{json, Value};
     use std::str::from_utf8;
+
+    static GIRL_WORD_INFO: Lazy<WordInfo> = Lazy::new(|| WordInfo {
+        book: "Joel".to_string(),
+        chapter: 3,
+        verse: 3,
+    });
+
+    static GIRL_MATCH_INFO: Lazy<MatchInfo> = Lazy::new(|| MatchInfo {
+        word_info: &GIRL_WORD_INFO,
+        link: "https://www.kingjamesbibleonline.org/Joel-3-3/".to_string(),
+    });
 
     #[actix_web::test]
     async fn test_formatted_response_code_200_ok() {
@@ -86,16 +95,10 @@ mod tests {
             // For some reason, this is one of the only words that only appears once in the bible/
             words: "Girl".to_string(),
         };
-        let expected_info = WordInfo {
-            book: "Joel".to_string(),
-            chapter: 3,
-            verse: 3,
-        };
         let expected_output: Vec<ReturnInfo> = vec![ReturnInfo {
             start_pos: 0,
             end_pos: 3,
-            matches: vec![&expected_info],
-            links: vec!["https://www.kingjamesbibleonline.org/Joel-3-3/".to_string()],
+            matches: vec![GIRL_MATCH_INFO.clone()],
         }];
         let json_words = Json(test_words);
         let resp = get_frequency(json_words).await;
@@ -108,23 +111,16 @@ mod tests {
         let test_words = Words {
             words: "Girl Girl".to_string(),
         };
-        let expected_info = WordInfo {
-            book: "Joel".to_string(),
-            chapter: 3,
-            verse: 3,
-        };
         let expected_output: Vec<ReturnInfo> = vec![
             ReturnInfo {
                 start_pos: 0,
                 end_pos: 3,
-                matches: vec![&expected_info],
-                links: vec!["https://www.kingjamesbibleonline.org/Joel-3-3/".to_string()],
+                matches: vec![GIRL_MATCH_INFO.clone()],
             },
             ReturnInfo {
                 start_pos: 5,
                 end_pos: 8,
-                matches: vec![&expected_info],
-                links: vec!["https://www.kingjamesbibleonline.org/Joel-3-3/".to_string()],
+                matches: vec![GIRL_MATCH_INFO.clone()],
             },
         ];
         let json_words = Json(test_words);
@@ -138,16 +134,10 @@ mod tests {
         let test_words = Words {
             words: "Girl Fauna".to_string(),
         };
-        let expected_info = WordInfo {
-            book: "Joel".to_string(),
-            chapter: 3,
-            verse: 3,
-        };
         let expected_output: Vec<ReturnInfo> = vec![ReturnInfo {
             start_pos: 0,
             end_pos: 3,
-            matches: vec![&expected_info],
-            links: vec!["https://www.kingjamesbibleonline.org/Joel-3-3/".to_string()],
+            matches: vec![GIRL_MATCH_INFO.clone()],
         }];
         let json_words = Json(test_words);
         let resp = get_frequency(json_words).await;
@@ -160,16 +150,10 @@ mod tests {
         let test_words = Words {
             words: "girl".to_string(),
         };
-        let expected_info = WordInfo {
-            book: "Joel".to_string(),
-            chapter: 3,
-            verse: 3,
-        };
         let expected_output: Vec<ReturnInfo> = vec![ReturnInfo {
             start_pos: 0,
             end_pos: 3,
-            matches: vec![&expected_info],
-            links: vec!["https://www.kingjamesbibleonline.org/Joel-3-3/".to_string()],
+            matches: vec![GIRL_MATCH_INFO.clone()],
         }];
         let json_words = Json(test_words);
         let resp = get_frequency(json_words).await;
@@ -190,8 +174,7 @@ mod tests {
         let expected_output: Vec<ReturnInfo> = vec![ReturnInfo {
             start_pos: 0,
             end_pos: 3,
-            matches: vec![&expected_info],
-            links: vec!["https://www.kingjamesbibleonline.org/Joel-3-3/".to_string()],
+            matches: vec![GIRL_MATCH_INFO.clone()],
         }];
         let json_words = Json(test_words);
         let resp = get_frequency(json_words).await;

--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -1,3 +1,4 @@
+use crate::models::matchinfo::MatchInfo;
 use crate::models::returninfo::ReturnInfo;
 use crate::models::wordinfo::WordInfo;
 use crate::models::words::Words;
@@ -25,14 +26,14 @@ fn lookup<'a>(index: usize, word: &str) -> Option<ReturnInfo<'a>> {
         Some(found_word_info) => Some(ReturnInfo {
             start_pos: index,
             end_pos: index + word.len() - 1,
-            matches: Vec::from_iter(found_word_info.iter()),
-            links: found_word_info
-                .iter()
-                .map(|item| {
-                    format!(
+            matches: found_word_info
+                .into_iter()
+                .map(|item| MatchInfo {
+                    word_info: item,
+                    link: format!(
                         "https://www.kingjamesbibleonline.org/{}-{}-{}/",
                         item.book, item.chapter, item.verse
-                    )
+                    ),
                 })
                 .collect(),
         }),

--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -46,8 +46,6 @@ pub fn config(cfg: &mut web::ServiceConfig) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::ops::Deref;
-
     use actix_web::{
         body::to_bytes,
         http::{self},
@@ -165,11 +163,6 @@ mod tests {
     async fn test_present_mixed_case_returns_array_of_return_info() {
         let test_words = Words {
             words: "gIrL".to_string(),
-        };
-        let expected_info = WordInfo {
-            book: "Joel".to_string(),
-            chapter: 3,
-            verse: 3,
         };
         let expected_output: Vec<ReturnInfo> = vec![ReturnInfo {
             start_pos: 0,

--- a/api/src/models/matchinfo.rs
+++ b/api/src/models/matchinfo.rs
@@ -1,7 +1,7 @@
 use crate::models::wordinfo::WordInfo;
 use serde::Serialize;
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 pub struct MatchInfo<'a> {
     #[serde(flatten)]
     pub word_info: &'a WordInfo,

--- a/api/src/models/matchinfo.rs
+++ b/api/src/models/matchinfo.rs
@@ -1,0 +1,9 @@
+use crate::models::wordinfo::WordInfo;
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub struct MatchInfo<'a> {
+    #[serde(flatten)]
+    pub word_info: &'a WordInfo,
+    pub link: String,
+}

--- a/api/src/models/mod.rs
+++ b/api/src/models/mod.rs
@@ -1,3 +1,4 @@
+pub mod matchinfo;
 pub mod returninfo;
 pub mod wordinfo;
 pub mod words;

--- a/api/src/models/returninfo.rs
+++ b/api/src/models/returninfo.rs
@@ -1,10 +1,9 @@
-use crate::models::wordinfo::WordInfo;
+use crate::models::matchinfo::MatchInfo;
 use serde::Serialize;
 
 #[derive(Serialize)]
 pub struct ReturnInfo<'a> {
     pub start_pos: usize,
     pub end_pos: usize,
-    pub matches: Vec<&'a WordInfo>,
-    pub links: Vec<String>,
+    pub matches: Vec<MatchInfo<'a>>,
 }

--- a/api/src/models/words.rs
+++ b/api/src/models/words.rs
@@ -4,9 +4,3 @@ use serde::{Deserialize, Serialize};
 pub struct Words {
     pub words: String,
 }
-
-impl Words {
-    pub fn from_text(text: String) -> Self {
-        Words { words: text }
-    }
-}


### PR DESCRIPTION
This PR replaces the existing seperated links and WordInfo implementation, adding an extra struct in MatchInfo and using serde's flatten feature to produce the below integrated JSON output:

![image](https://github.com/Manoyerro/none-of-these-words-are-in-the-bible/assets/22503395/dfda16fe-40ce-481d-88bf-97a363a2888b)

The unused from_text method in the Words struct is also removed in this PR.